### PR TITLE
Character switch no longer resets view to 'Fluff' tab

### DIFF
--- a/pathfinder-toolkit/src/com/lateensoft/pathfinder/toolkit/views/character/PTCharacterSheetFragment.java
+++ b/pathfinder-toolkit/src/com/lateensoft/pathfinder/toolkit/views/character/PTCharacterSheetFragment.java
@@ -261,11 +261,12 @@ public abstract class PTCharacterSheetFragment extends PTBasePageFragment {
 		case R.id.mi_character_list:
 			// Check if "currently selected" character is the same as saved one
 			if (m_characterSelectedInDialog != m_currentCharacterID) {
-				performUpdateReset();
+				updateDatabase();
 
 				PTSharedPreferences.getInstance().putLong(
 						PTSharedPreferences.KEY_LONG_SELECTED_CHARACTER_ID, m_characterSelectedInDialog);
 				loadCurrentCharacter();
+				updateTitle();
 			}
 			break;
 

--- a/pathfinder-toolkit/src/com/lateensoft/pathfinder/toolkit/views/character/PTCharacterSheetFragment.java
+++ b/pathfinder-toolkit/src/com/lateensoft/pathfinder/toolkit/views/character/PTCharacterSheetFragment.java
@@ -104,8 +104,8 @@ public abstract class PTCharacterSheetFragment extends PTBasePageFragment {
 			if (getRootView() != null) {
 				updateFragmentUI();
 			}
-
 		}
+		updateTitle();
 	}
 
 	/**
@@ -266,7 +266,6 @@ public abstract class PTCharacterSheetFragment extends PTBasePageFragment {
 				PTSharedPreferences.getInstance().putLong(
 						PTSharedPreferences.KEY_LONG_SELECTED_CHARACTER_ID, m_characterSelectedInDialog);
 				loadCurrentCharacter();
-				updateTitle();
 			}
 			break;
 


### PR DESCRIPTION
updateDatabase worked as suggested. Was also necessary to updateTitle to refresh displayed character name.
