### PR TITLE
Enabled screen auto-rotation based on device orientation

### DIFF
--- a/pathfinder-toolkit/src/com/lateensoft/pathfinder/toolkit/PTMainActivity.java
+++ b/pathfinder-toolkit/src/com/lateensoft/pathfinder/toolkit/PTMainActivity.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -64,7 +65,10 @@ public class PTMainActivity extends Activity implements
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		
+
+		// Enable auto-rotation of screen based on device orientation
+		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+
 		if (savedInstanceState != null) {
 			m_currentFragmentId = savedInstanceState.getLong(KEY_CURRENT_FRAGMENT);
 		}


### PR DESCRIPTION
Used ActivityInfo to set screen orientation to be unlocked to any particular orientation. If device has screen rotation enabled, screen now rotates automatically.
