### PR TITLE
#36 Bugfix - Moving active character up in list no longer lets previous ...

### DIFF
--- a/pathfinder-toolkit/src/main/com/lateensoft/pathfinder/toolkit/views/encounter/EncounterPresenter.java
+++ b/pathfinder-toolkit/src/main/com/lateensoft/pathfinder/toolkit/views/encounter/EncounterPresenter.java
@@ -237,7 +237,12 @@ public class EncounterPresenter {
     public void onParticipantOrderChangeConfirmed(int initialPosition, int newPosition) {
         if (initialPosition != newPosition &&
                 Objects.equal(encounter.get(newPosition), encounter.getCurrentTurn())) {
-            setCurrentTurn(initialPosition);
+            if (initialPosition < newPosition)
+                // Character moved down in list
+                setCurrentTurn(initialPosition);
+            else
+                // Character moved up in list
+                setCurrentTurn((initialPosition + 1) % encounter.size());
         }
     }
 


### PR DESCRIPTION
...character take a second turn

Moving active character from bottom to top of list allows them to continue to have current turn as cyclical order has not changed
